### PR TITLE
registerTimezones(): register timezones with key

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function registerTimezones() {
     const comp = new ICAL.Component(parsed);
     const vtimezone = comp.getFirstSubcomponent('vtimezone');
 
-    ICAL.TimezoneService.register(vtimezone);
+    ICAL.TimezoneService.register(key, new ICAL.Timezone(vtimezone));
   });
 }
 


### PR DESCRIPTION
- Allows timezones with multiple names to be registered, e.g. "US/Pacific" as an alias of "America/Los_Angeles"