### PR TITLE
Send only related exceptions for event creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ class IcalExpander {
     this.component = new ICAL.Component(this.jCalData);
 
     const allVEvents = this.component.getAllSubcomponents('vevent');
-    this.events = allVEvents.map(vevent => {
+    this.events = allVEvents.map((vevent) => {
       const subEvents = vevent.hasProperty('recurrence-id')
         ? null
         : allVEvents.filter(subEvent => subEvent !== vevent && subEvent.getFirstPropertyValue('uid') === vevent.getFirstPropertyValue('uid'));

--- a/index.js
+++ b/index.js
@@ -14,7 +14,14 @@ class IcalExpander {
 
     this.jCalData = ICAL.parse(opts.ics);
     this.component = new ICAL.Component(this.jCalData);
-    this.events = this.component.getAllSubcomponents('vevent').map(vevent => new ICAL.Event(vevent));
+    
+    const allVEvents = this.component.getAllSubcomponents('vevent');
+    this.events = allVEvents.map((vevent) => {
+      const subEvents = vevent.hasProperty('recurrence-id')
+        ? null
+        : allVEvents.filter((subEvent) => subEvent !== vevent && subEvent.getFirstPropertyValue('uid') === vevent.getFirstPropertyValue('uid'));
+      return new ICAL.Event(vevent, { exceptions: subEvents });
+    });
 
     if (this.skipInvalidDates) {
       this.events = this.events.filter((evt) => {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,11 @@ class IcalExpander {
       const subEvents = vevent.hasProperty('recurrence-id')
         ? null
         : allVEvents.filter(subEvent => subEvent !== vevent && subEvent.getFirstPropertyValue('uid') === vevent.getFirstPropertyValue('uid'));
-      return new ICAL.Event(vevent, { exceptions: subEvents });
+      try {
+        return new ICAL.Event(vevent, { exceptions: subEvents });
+      } catch (err) {
+        return new ICAL.Event(vevent);
+      }
     });
 
     if (this.skipInvalidDates) {

--- a/index.js
+++ b/index.js
@@ -14,12 +14,12 @@ class IcalExpander {
 
     this.jCalData = ICAL.parse(opts.ics);
     this.component = new ICAL.Component(this.jCalData);
-    
+
     const allVEvents = this.component.getAllSubcomponents('vevent');
-    this.events = allVEvents.map((vevent) => {
+    this.events = allVEvents.map(vevent => {
       const subEvents = vevent.hasProperty('recurrence-id')
         ? null
-        : allVEvents.filter((subEvent) => subEvent !== vevent && subEvent.getFirstPropertyValue('uid') === vevent.getFirstPropertyValue('uid'));
+        : allVEvents.filter(subEvent => subEvent !== vevent && subEvent.getFirstPropertyValue('uid') === vevent.getFirstPropertyValue('uid'));
       return new ICAL.Event(vevent, { exceptions: subEvents });
     });
 


### PR DESCRIPTION
With version 3.1.0, when an event was created all exceptions would exist under each event.  This caused issues for me when there were recurrences with the same start times. The updated code passes in only the exceptions related to this particular UID.