### PR TITLE
add filter method

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ class IcalExpander {
             const occurrence = event.getOccurrenceDetails(next);
 
             const times = getTimes(occurrence);
-            const { startTime, endTime } = times;
+            const { startTime } = times;
             const isOccurrenceExcluded = exdates.indexOf(startTime) !== -1;
 
             // TODO check that within same day?


### PR DESCRIPTION
Gives the user more control as to what arrays are returned.

The benefit is that it allows filtering during iteration which is memory
friendly.

Possible related issue:

- https://github.com/mifi/ical-expander/issues/15